### PR TITLE
fixed the fileUpload component and also added the test cases

### DIFF
--- a/packages/react-vanilla-components/__tests__/components/FileUpload.test.tsx
+++ b/packages/react-vanilla-components/__tests__/components/FileUpload.test.tsx
@@ -311,4 +311,107 @@ describe("File Upload", () => {
     expect(input).toHaveLength(1);
     expect(input[0]).toHaveAttribute('aria-describedby', `${f.id}__longdescription ${f.id}__shortdescription`)
   })
+
+  test("should allow re-uploading same file after removal", async () => {
+    const f = {
+      ...field,
+      type: "file",
+    };
+    const { renderResponse } = await helper(f);
+    
+    // Get the file input element directly (like other tests do)
+    const input = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__widget");
+    
+    // 1. Upload initial file
+    const file = new File(["(⌐□_□)"], "test-document.pdf", { type: "application/pdf" });
+    userEvent.upload(input[0] as HTMLInputElement, file);
+    
+    // Verify file was uploaded
+    expect(renderResponse.queryByText("test-document.pdf")).toBeTruthy();
+    
+    // 2. Remove the file using the remove button
+    const removeButton = renderResponse.getByLabelText("Remove file");
+    userEvent.click(removeButton);
+    
+    // Verify file was removed
+    expect(renderResponse.queryByText("test-document.pdf")).toBeFalsy();
+    
+    // 3. Re-upload the same file (this tests the bug fix)
+    const newFile = new File(["(⌐□_□)"], "test-document.pdf", { type: "application/pdf" });
+    userEvent.upload(input[0] as HTMLInputElement, newFile);
+    
+    // 4. Verify the same file appears correctly after re-upload
+    expect(renderResponse.queryByText("test-document.pdf")).toBeTruthy();
+  });
+
+  test("should handle duplicate filenames correctly without removing wrong file", async () => {
+    const f = {
+      ...field,
+      type: "file[]",
+    };
+    const { renderResponse } = await helper(f);
+
+    const input = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__widget");
+    
+    // Upload first document
+    const largerContent = Array(100).fill('(⌐□_□)').join('');
+    const document1 = new File([largerContent], "document.pdf", { type: "application/pdf" });
+    userEvent.upload(input[0] as HTMLInputElement, document1);
+    
+    // Upload image file to create separation between duplicate names
+    const imageFile = new File(["image data"], "image.jpg", { type: "image/jpeg" });
+    userEvent.upload(input[0] as HTMLInputElement, imageFile);
+    
+    // Upload second document with same filename but different content
+    const smallerContent = '(⌐□_□)';
+    const document2 = new File([smallerContent], "document.pdf", { type: "application/pdf" });
+    userEvent.upload(input[0] as HTMLInputElement, document2);
+    
+    // Verify all files are present
+    const fileItems = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__fileitem");
+    expect(fileItems).toHaveLength(3);
+    
+    const fileSizes = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__filesize");
+    expect(fileSizes).toHaveLength(3);
+    const sizeTexts = Array.from(fileSizes).map(el => el.textContent);
+    expect(sizeTexts.filter(size => size !== sizeTexts[0])).toHaveLength(2);
+    
+    expect(renderResponse.queryByText("image.jpg")).toBeTruthy();
+    
+    const removeButtons = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__filedelete");
+    expect(removeButtons).toHaveLength(3);
+    
+    // Remove the first uploaded document
+    userEvent.click(removeButtons[0] as HTMLButtonElement);
+    
+    // Verify exactly 2 files remain
+    const remainingFileItems = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__fileitem");
+    expect(remainingFileItems).toHaveLength(2);
+    
+    const remainingFileSizes = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__filesize");
+    const remainingSizeTexts = Array.from(remainingFileSizes).map(el => el.textContent);
+    expect(remainingSizeTexts).toHaveLength(2);
+    
+    expect(renderResponse.queryByText("image.jpg")).toBeTruthy();
+    expect(renderResponse.queryByText("document.pdf")).toBeTruthy();
+    
+    // Remove the image file to verify the second document remains
+    const updatedRemoveButtons = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__filedelete");
+    expect(updatedRemoveButtons).toHaveLength(2);
+    
+    const imageRemoveButton = Array.from(updatedRemoveButtons).find((button) => {
+      const fileItem = button.closest('.cmp-adaptiveform-fileinput__fileitem');
+      const fileName = fileItem?.querySelector('.cmp-adaptiveform-fileinput__filename')?.textContent;
+      return fileName === 'image.jpg';
+    });
+    userEvent.click(imageRemoveButton as HTMLButtonElement);
+    
+    // Verify only the second document remains
+    const finalFileItems = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__fileitem");
+    expect(finalFileItems).toHaveLength(1);
+    
+    const finalFileSizes = renderResponse.container.getElementsByClassName("cmp-adaptiveform-fileinput__filesize");
+    expect(finalFileSizes).toHaveLength(1);
+    expect(renderResponse.queryByText("image.jpg")).toBeFalsy();
+  });
 });


### PR DESCRIPTION
# Fix: File Upload Re-upload Issue

## Description

This PR fixes a critical bug in the FileUpload component where users could not re-upload the same file after removing it. Another  was to support the file upload feature in which the user can upload multiple files with same name.

**Key Changes:**
- Clear file input value after file selection to enable re-uploading the same file
- Implement unique identifier (UID) system for better file tracking and duplicate handling
- Added tests for re-upload scenarios and duplicate filename handling

## Related Issue

- https://github.com/adobe/aem-forms-headless-components/issues/156

## Motivation and Context

## How Has This Been Tested?

- **Unit Tests Added:**
  - `should allow re-uploading same file after removal` - Tests the core bug fix
  - `should handle duplicate filenames correctly without removing wrong file` - Tests improved file tracking with UIDs

- **Manual Testing:**
  1. Upload a file → verify it appears in the list
  2. Remove the file → verify it's removed from the list
  3. Upload the same file again → verify it can be re-uploaded successfully
  4. Test with multiple files having the same name → verify correct file is removed


## Screenshots (if appropriate):

<img width="2292" height="724" alt="image" src="https://github.com/user-attachments/assets/77243fa9-6533-4acb-b66f-7aa53e6a1f33" />


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.