### PR TITLE
FORMS-23374 : Date field component issue in headless

### DIFF
--- a/packages/react-vanilla-components/src/components/DateInput.tsx
+++ b/packages/react-vanilla-components/src/components/DateInput.tsx
@@ -23,23 +23,9 @@ import { PROPS } from '../utils/type';
 import FieldWrapper from './common/FieldWrapper';
 import { syncAriaDescribedBy } from '../utils/utils';
 
-// Helper function to convert date to ISO format (YYYY-MM-DD)
-const toISODateString = (dateValue: string | number | undefined): string | undefined => {
-  if (dateValue === undefined || dateValue === null) {return undefined;}
-  try {
-    const date = new Date(dateValue);
-    if (isNaN(date.getTime())) {return undefined;}
-    return date.toISOString().split('T')[0];
-  } catch {
-    return undefined;
-  }
-};
-
 const DateInput = (props: PROPS) => {
   const { id, label, value, required, name, readOnly, placeholder, visible, enabled, appliedCssClassNames, valid, minimum, maximum } = props;
   const finalValue = value === undefined ? '' : value;
-  const minDate = toISODateString(minimum);
-  const maxDate = toISODateString(maximum);
 
   const changeHandler = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;
@@ -78,8 +64,8 @@ const DateInput = (props: PROPS) => {
           value={finalValue}
           name={name}
           required={required}
-          min={minDate}
-          max={maxDate}
+          min={minimum}
+          max={maximum}
           onChange={changeHandler}
           className={'cmp-adaptiveform-datepicker__widget'}
           title={props.tooltipText || ''}


### PR DESCRIPTION

## Description

Date-field is not honouring the headless contract for "maximum" and "minimum" attributes.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
