### PR TITLE
FORMS-25008 add multiselect support for DropDown component

### DIFF
--- a/packages/react-vanilla-components/__tests__/components/DropDown.test.tsx
+++ b/packages/react-vanilla-components/__tests__/components/DropDown.test.tsx
@@ -86,6 +86,20 @@ const fieldFour = {
   enum: ["1","2"],
   placeholder: "choose the option"
 }
+
+const fieldMultiSelect = {
+  name: "dropdown",
+  visible: true,
+  type: "string[]",
+  label: {
+    value: "Drop Down Multi",
+  },
+  fieldType: "drop-down",
+  placeholder: "select",
+  enum: [1, 2, 3],
+  enumNames: ["option 1", "option 2", "option 3"],
+};
+
 const helper = renderComponent(DropDown);
 
 describe("Drop Down", () => {
@@ -249,5 +263,32 @@ describe("Drop Down", () => {
     // 2) Select 'clear value' (enum '2') on source -> target should reset to empty
     await userEvent.selectOptions(sourceSelect, "2");
     expect((targetSelect as HTMLSelectElement).value).toBe("");
+  });
+
+  test("multiselect: multiple attribute is set when type is string[]", async () => {
+    const { renderResponse } = await helper(fieldMultiSelect);
+    const select = renderResponse.getByTestId("select");
+    expect(select).toHaveAttribute("multiple");
+  });
+
+  test("multiselect: selecting multiple options dispatches an array value", async () => {
+    const { renderResponse, element } = await helper(fieldMultiSelect);
+    const select = renderResponse.getByTestId("select") as HTMLSelectElement;
+    await userEvent.selectOptions(select, ["1", "2"]);
+    expect(Array.isArray(element?.value)).toBe(true);
+    const selectedOptions = Array.from(select.selectedOptions).map(o => o.value);
+    expect(selectedOptions).toEqual(["1", "2"]);
+  });
+
+  test("multiselect: all selected options reflect in widget while unselected ones do not", async () => {
+    const { renderResponse } = await helper(fieldMultiSelect);
+    const select = renderResponse.getByTestId("select") as HTMLSelectElement;
+    await userEvent.selectOptions(select, ["1", "2"]);
+    const opt1 = renderResponse.getByRole("option", { name: "option 1" }) as HTMLOptionElement;
+    const opt2 = renderResponse.getByRole("option", { name: "option 2" }) as HTMLOptionElement;
+    const opt3 = renderResponse.getByRole("option", { name: "option 3" }) as HTMLOptionElement;
+    expect(opt1.selected).toBe(true);
+    expect(opt2.selected).toBe(true);
+    expect(opt3.selected).toBe(false);
   });
 });

--- a/packages/react-vanilla-components/src/components/DropDown.tsx
+++ b/packages/react-vanilla-components/src/components/DropDown.tsx
@@ -24,17 +24,25 @@ import FieldWrapper from './common/FieldWrapper';
 import { syncAriaDescribedBy } from '../utils/utils';
 
 const DropDown = (props: PROPS) => {
-  const { id, enum: enums, enumNames, label, value, placeholder, name, required, enabled, visible, appliedCssClassNames, valid } = props;
+  const { id, enum: enums, enumNames, label, value, placeholder, name, required, enabled, visible, appliedCssClassNames, valid, isMultiSelect } = props;
   const dropValue = enumNames && enumNames.length ? enumNames : enums || [];
-  let selectedValue = value ?? '';
+  const selectedValue = isMultiSelect
+    ? (Array.isArray(value) ? (value as any[]).map(String) : (value !== null && value !== undefined ? [String(value)] : []))
+    : (value ?? '');
+  const isFilled = isMultiSelect ? (Array.isArray(value) && value.length > 0) : !!value;
   const changeHandler = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
-    const val = event.target.value;
-    props.dispatchChange(val);
-  }, [props.dispatchChange]);
+    if (isMultiSelect) {
+      const selected = Array.from(event.target.selectedOptions).map(o => o.value);
+      props.dispatchChange(selected);
+    } else {
+      const val = event.target.value;
+      props.dispatchChange(val);
+    }
+  }, [props.dispatchChange, isMultiSelect]);
 
   return (
     <div
-      className={`cmp-adaptiveform-dropdown cmp-adaptiveform-dropdown--${value ? 'filled' : 'empty'} ${appliedCssClassNames || ''}`}
+      className={`cmp-adaptiveform-dropdown cmp-adaptiveform-dropdown--${isFilled ? 'filled' : 'empty'} ${appliedCssClassNames || ''}`}
       data-cmp-is="adaptiveFormDropDown"
       data-cmp-visible={visible}
       data-cmp-enabled={enabled}
@@ -57,7 +65,8 @@ const DropDown = (props: PROPS) => {
           title={props.tooltipText || ''}
           className={'cmp-adaptiveform-dropdown__widget'}
           onChange={changeHandler}
-          value={selectedValue}
+          multiple={isMultiSelect || false}
+          value={selectedValue as any}
           required={required}
           disabled={!enabled}
           aria-invalid={!valid}

--- a/packages/react-vanilla-components/src/components/DropDown.tsx
+++ b/packages/react-vanilla-components/src/components/DropDown.tsx
@@ -27,7 +27,7 @@ const DropDown = (props: PROPS) => {
   const { id, enum: enums, enumNames, label, value, placeholder, name, required, enabled, visible, appliedCssClassNames, valid, isMultiSelect } = props;
   const dropValue = enumNames && enumNames.length ? enumNames : enums || [];
   const selectedValue = isMultiSelect
-    ? (Array.isArray(value) ? (value as any[]).map(String) : (value !== null && value !== undefined ? [String(value)] : []))
+    ? (Array.isArray(value) ? value : (value !== null && value !== undefined ? [value] : []))
     : (value ?? '');
   const isFilled = isMultiSelect ? (Array.isArray(value) && value.length > 0) : !!value;
   const changeHandler = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {

--- a/packages/react-vanilla-components/src/utils/type.tsx
+++ b/packages/react-vanilla-components/src/utils/type.tsx
@@ -22,6 +22,7 @@ export type FieldViewState = WithViewState<FieldJson>;
 export type PROPS = State<FieldJson & Handlers & {
   isError?: boolean,
   isInFocus?: boolean,
+  isMultiSelect?: boolean,
   layout?: {
     [key: string]: any;
   },

--- a/packages/react-vanilla-components/src/utils/withRuleEngine.tsx
+++ b/packages/react-vanilla-components/src/utils/withRuleEngine.tsx
@@ -84,7 +84,7 @@ export function withRuleEngine(Component: JSXElementConstructor<any>) {
         visible: state.label?.visible !== false
       },
       isError: getValidationState(state) === 'invalid',
-      isMultiSelect: state.type === 'string[]',
+      isMultiSelect: state.type?.includes('[]'),
       errorMessage: formateErrorMessage(state),
       layout: {
         orientation: 'horizontal',

--- a/packages/react-vanilla-components/src/utils/withRuleEngine.tsx
+++ b/packages/react-vanilla-components/src/utils/withRuleEngine.tsx
@@ -84,6 +84,7 @@ export function withRuleEngine(Component: JSXElementConstructor<any>) {
         visible: state.label?.visible !== false
       },
       isError: getValidationState(state) === 'invalid',
+      isMultiSelect: state.type === 'string[]',
       errorMessage: formateErrorMessage(state),
       layout: {
         orientation: 'horizontal',


### PR DESCRIPTION
## Summary

- Added `multiple` attribute to the `<select>` element in `DropDown.tsx` when `isMultiSelect` is true
- Change handler now collects all selected option values as a `string[]` for multiselect dropdowns, dispatching an array instead of a single value
- `withRuleEngine.tsx` derives `isMultiSelect` from `state.type === 'string[]'`
- Added `isMultiSelect?: boolean` to the `PROPS` type in `type.tsx`
- `isFilled` check updated to handle array values correctly for CSS class toggling


## JIRA

[FORMS-25008](https://jira.corp.adobe.com/browse/FORMS-25008)