### PR TITLE
FORMS-25113 Sow multiselect options as scrollable visible list

### DIFF
--- a/packages/react-vanilla-components/src/components/DropDown.tsx
+++ b/packages/react-vanilla-components/src/components/DropDown.tsx
@@ -66,6 +66,8 @@ const DropDown = (props: PROPS) => {
           className={'cmp-adaptiveform-dropdown__widget'}
           onChange={changeHandler}
           multiple={isMultiSelect || false}
+          size={isMultiSelect ? Math.min(dropValue.length + 1, 6) : undefined}
+          style={isMultiSelect ? { height: 'auto' } : undefined}
           value={selectedValue as any}
           required={required}
           disabled={!enabled}


### PR DESCRIPTION
## Problem

When a dropdown was configured as multiselect (`type: string[]`), the `<select>` element rendered with a fixed height of ~48px — just enough to show a single row — and was scrollable. This made it very difficult for users to see and pick from the available options.

## Solution

- Added `size={Math.min(options.length + 1, 6)}` so the multiselect renders as an expanded visible list (capped at 6 rows to avoid taking up too much vertical space)
- Added `style={{ height: 'auto' }}` to override any fixed-height CSS that was collapsing the list back to 48px

Single-select dropdowns are unaffected — both attributes are only applied when `isMultiSelect` is true.

## Test plan
- [x] All 13 existing DropDown tests pass
- [x] Multiselect renders as an expanded list showing up to 6 options at a time
- [x] Single-select dropdown behavior and appearance unchanged

Fixes: [FORMS-25113](https://jira.corp.adobe.com/browse/FORMS-25113)

Before:
<img width="504" height="126" alt="image" src="https://github.com/user-attachments/assets/7a88bbb3-b294-48c4-bf6e-d3138bff8402" />

After:
<img width="1114" height="142" alt="image" src="https://github.com/user-attachments/assets/0c94c57b-68ef-4aad-b3ab-7bd4626b6a73" />

